### PR TITLE
feat: implement XP progression and leveling system

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,6 +10,9 @@ Author:
   Mickael [aut]
 Maintainer: Who to complain to <yourfault@somewhere.net>
 Depends: R (>= 4.1.0)
+Imports: crayon, progress
+Suggests: testthat (>= 3.0.0)
+Config/testthat/edition: 3
 Description: The `Rwards` package is designed to transform the experience of
   learning R by turning errors into opportunities for growth and engagement. By
   rewarding users for making mistakes, this package aims to reduce the anxiety

--- a/R/Rwards.R
+++ b/R/Rwards.R
@@ -1,3 +1,5 @@
+error_tracker <- new.env(parent = emptyenv())
+
 # Cache functions
 get_cache_dir <- function() {
   tools::R_user_dir("Rwards", which = "data")
@@ -130,9 +132,6 @@ evaluate_code <- function(expr) {
 }
 
 .onLoad <- function(libname, pkgname) {
-  # Create global environment to store error types and points
-  error_tracker <<- new.env()
-  
   # Load saved progress
   load_progress()
   

--- a/R/Rwards.R
+++ b/R/Rwards.R
@@ -1,77 +1,124 @@
+# Cache functions
+get_cache_dir <- function() {
+  tools::R_user_dir("Rwards", which = "data")
+}
+
+get_cache_file <- function() {
+  file.path(get_cache_dir(), "progress.rds")
+}
+
+load_progress <- function() {
+  cache_file <- get_cache_file()
+  if (file.exists(cache_file)) {
+    tryCatch({
+      data <- readRDS(cache_file)
+      error_tracker$error_types <- data$error_types
+      error_tracker$points <- data$points
+      # Backwards compatibility check
+      if (is.null(error_tracker$points)) error_tracker$points <- 0
+      if (is.null(error_tracker$error_types)) error_tracker$error_types <- list()
+    }, error = function(e) {
+      # On failure to read, just start fresh
+      error_tracker$error_types <- list()
+      error_tracker$points <- 0
+    })
+  } else {
+    error_tracker$error_types <- list()
+    error_tracker$points <- 0
+  }
+}
+
+save_progress <- function() {
+  cache_dir <- get_cache_dir()
+  if (!dir.exists(cache_dir)) {
+    dir.create(cache_dir, recursive = TRUE, showWarnings = FALSE)
+  }
+  data <- list(
+    error_types = error_tracker$error_types,
+    points = error_tracker$points
+  )
+  saveRDS(data, file = get_cache_file())
+}
+
 # Function to handle errors
 error_handler <- function(e) {
   # Error message
   error_message <- conditionMessage(e)
   
-  # Check if it's a new type of error (without modifying the original error message)
+  # Current level info before points added
+  info_before <- get_level_info(error_tracker$points)
+  
+  # Check if it's a new type of error
   if (!(error_message %in% names(error_tracker$error_types))) {
-    error_tracker$error_types[[error_message]] <- TRUE  # Track new error type
-    error_tracker$points <- error_tracker$points + 3     # Add 3 points for a new error type
+    error_tracker$error_types[[error_message]] <- TRUE
+    error_tracker$points <- error_tracker$points + 150
   } else {
-    error_tracker$points <- error_tracker$points + 1     # Add 1 point for a recurring error
-  }
-
-  # Update progress bar based on points
-  update_progress_bar()
-  
-  # Assign the color based on points
-  color_func <- if (error_tracker$points >= 500) {
-    crayon::red
-  } else if (error_tracker$points >= 250) {
-    crayon::magenta
-  } else if (error_tracker$points >= 100) {
-    crayon::blue
-  } else if (error_tracker$points >= 50) {
-    crayon::green
-  } else if (error_tracker$points >= 20) {
-    crayon::yellow
-  } else {
-    crayon::silver
-  }
-
-  # Create a positive message
-  message <- if (error_tracker$points >= 500) {
-    "You're doing a fantastic job! Way to go!"
-  } else if (error_tracker$points >= 250) {
-    "You're getting better with each step!"
-  } else if (error_tracker$points >= 100) {
-    "Nice work! You'll get this!"
-  } else if (error_tracker$points >= 50) {
-    "Keep going, every mistake is progress!"
-  } else if (error_tracker$points >= 20) {
-    "You're doing awesome!"
-  } else if (error_tracker$points >= 4) {
-    "More mistakes will keep earning you more points!"
-  } else {
-    paste("This is your first mistake. Humans learn by making mistakes and",
-          "fixing them. Keep up the good work and you will accumulate points!")
+    error_tracker$points <- error_tracker$points + 50
   }
   
-  # Print the message in the selected color
-  message(color_func(paste("\nError detected:", error_message)))
-  message(color_func(paste("Points:", error_tracker$points)))
-  message(color_func(message))
+  # Save to cache
+  save_progress()
+  
+  # Current level info after points added
+  info_after <- get_level_info(error_tracker$points)
+  
+  # Initialize or Update progress bar if level changed or bar not present
+  if (is.null(error_tracker$progress) || info_before$level != info_after$level) {
+    initialize_progress_bar(info_after)
+  }
+  
+  update_progress_bar(info_after)
+  
+  # Print the error details first
+  message(crayon::red(paste("\nError detected:", error_message)))
+  
+  # Level up announcement or positive message
+  if (info_after$level > info_before$level) {
+    message(crayon::bold(crayon::yellow(
+      sprintf("\n\u2B50 LEVEL UP! \u2B50 You reached Level %d: %s!", info_after$level, info_after$title)
+    )))
+  } else {
+    # Random positive message
+    msg <- sample(positive_messages, 1)
+    message(crayon::green(sprintf("\n%s", msg)))
+  }
+  
+  message(crayon::cyan(sprintf("Total XP: %d", error_tracker$points)))
   
   # Return the original error for normal propagation
   return(e)
 }
 
 # Initialize the progress bar
-initialize_progress_bar <- function() {
+initialize_progress_bar <- function(info) {
+  total_xp_for_level <- info$next_threshold - info$prev_threshold
+  if (total_xp_for_level <= 0) total_xp_for_level <- 1 # safety
+  
   error_tracker$progress <- progress::progress_bar$new(
-    format = "Progress [:bar] :percent Points: :points",
-    total = error_tracker$goal,  # Set the goal for the total progress
-    clear = FALSE, width = 60
+    format = sprintf("[Level %d: %s] Progress to next level: [:bar] :percent XP: :current_xp/:total_xp", info$level, info$title),
+    total = total_xp_for_level,
+    clear = FALSE, width = 80
   )
 }
 
 # Update progress bar
-update_progress_bar <- function() {
-  points <- error_tracker$points
-  if (points > error_tracker$goal) {
-    points <- error_tracker$goal  # Ensure progress doesn't go beyond the goal
+update_progress_bar <- function(info) {
+  current_xp_in_level <- error_tracker$points - info$prev_threshold
+  total_xp_for_level <- info$next_threshold - info$prev_threshold
+  if (total_xp_for_level <= 0) total_xp_for_level <- 1
+  
+  # Cap progress at total to prevent errors
+  if (current_xp_in_level > total_xp_for_level) {
+    current_xp_in_level <- total_xp_for_level
   }
-  error_tracker$progress$tick(tokens = list(points = error_tracker$points))
+  
+  error_tracker$progress$update(
+    ratio = current_xp_in_level / total_xp_for_level,
+    tokens = list(
+      current_xp = current_xp_in_level,
+      total_xp = total_xp_for_level
+    )
+  )
 }
 
 # Function to evaluate code and catch errors
@@ -85,12 +132,13 @@ evaluate_code <- function(expr) {
 .onLoad <- function(libname, pkgname) {
   # Create global environment to store error types and points
   error_tracker <<- new.env()
-  error_tracker$error_types <<- list()  # To track unique error messages
-  error_tracker$points <<- 0            # Total points
-  error_tracker$goal <<- 500            # Set a goal for total points
   
-  # Initialize progress bar when the package loads
-  initialize_progress_bar()
+  # Load saved progress
+  load_progress()
+  
+  # Initialize progress bar
+  info <- get_level_info(error_tracker$points)
+  initialize_progress_bar(info)
   
   # Set custom error handler that doesn't require eval
   options(error = function() {
@@ -100,5 +148,5 @@ evaluate_code <- function(expr) {
     error_handler(simpleError(e))
   })
   
-  message("Rwards ready to reward!")
+  message("Rwards ready to reward! Set 'options(Rwards.theme = \"cyberpunk\")' for a different flavor.")
 }

--- a/R/levels.R
+++ b/R/levels.R
@@ -1,0 +1,72 @@
+# XP Thresholds based on Diablo 2 curve from levels.md
+xp_thresholds <- c(
+  500,     # Level 1
+  1625,    # Level 2
+  3875,    # Level 3
+  8875,    # Level 4
+  19025,   # Level 5
+  33650,   # Level 6
+  52775,   # Level 7
+  75275,   # Level 8
+  109025,  # Level 9
+  154025   # Level 10
+)
+
+# Level Titles Themes
+level_themes <- list(
+  basic = c(
+    "Novice", "Explorer", "Tinkerer", "Problem Solver", "Builder", 
+    "Debugger", "Strategist", "Hacker", "Architect", "Mastermind"
+  ),
+  cyberpunk = c(
+    "Wired Rookie", "Neon Scout", "Script Tinkerer", "Console Runner", 
+    "Code Slinger", "Signal Cracker", "Firewall Buster", "Ghost in the Net", 
+    "System Phantom", "The Rootwalker"
+  )
+)
+
+# Random positive messages
+positive_messages <- c(
+  "Every mistake is a stepping stone to mastery!",
+  "Another error? Just another puzzle piece falling into place.",
+  "You're not failing, you're learning what doesn't work.",
+  "Debugging is like being a detective in a crime movie where you are also the murderer.",
+  "Great job! Now you know one more way NOT to do it.",
+  "Oops! But hey, that's how we learn.",
+  "Keep at it! Even the best developers see this all the time.",
+  "Don't worry, even R gets confused sometimes.",
+  "Embrace the red text! It's just R's way of talking to you.",
+  "You're doing awesome. A little bug can't stop you!"
+)
+
+get_level_info <- function(xp) {
+  level <- sum(xp >= xp_thresholds) + 1
+  if (level > length(xp_thresholds)) {
+    level <- length(xp_thresholds) # Max level cap
+  }
+  
+  theme_name <- getOption("Rwards.theme", default = "basic")
+  if (!theme_name %in% names(level_themes)) {
+    theme_name <- "basic"
+  }
+  
+  title <- level_themes[[theme_name]][level]
+  
+  if (level == 1) {
+    prev_threshold <- 0
+    next_threshold <- xp_thresholds[1]
+  } else if (level == length(xp_thresholds)) {
+    prev_threshold <- xp_thresholds[level - 1]
+    next_threshold <- xp_thresholds[level] # Stay at max
+  } else {
+    prev_threshold <- xp_thresholds[level - 1]
+    next_threshold <- xp_thresholds[level]
+  }
+  
+  list(
+    level = level,
+    title = title,
+    next_threshold = next_threshold,
+    prev_threshold = prev_threshold
+  )
+}

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ The `Rwards` package is designed to transform the experience of learning R by tu
 - [x] Change error_tracker to progress tracker or exp (stay positive)
 - [ ] pride_colour color palette: new color when new error discovered
 - [ ] Add language (en/fr/de/...) option
-- [ ] Add a sense of progression/level-up as a gratification mechanism (eg. novice, amateur, ..., bugmaster)
-- [ ] Keep track of points between sessions? sort of a cache?
+- [x] Add a sense of progression/level-up as a gratification mechanism (eg. novice, amateur, ..., bugmaster)
+- [x] Keep track of points between sessions? sort of a cache?
 - [ ] Remove redundant text in error message.
-- [ ] Show progress until next level?
+- [x] Show progress until next level?
 - [ ] Couleur (pride color palette) pour découvrir une nouvelle erreur? 
 - [ ] Put .onLoad inside zzz.R
 - [ ] Minimal doc
@@ -32,4 +32,8 @@ devtools::install("Rwards")
 library(Rwards)
 trythis
 ```
+
+## AI Acknowledgement
+
+The development of some features and tests in this package were accelerated with the assistance of an AI coding assistant.
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,16 @@
 # Rwards
 
-The `Rwards` package is designed to transform the experience of learning R by turning errors into opportunities for growth and engagement. By rewarding users for making mistakes, this package aims to reduce the anxiety often associated with error messages and fosters a positive learning environment for newcomers. Users earn points or badges for each error encountered, encouraging exploration and experimentation without fear of failure. With built-in tips and helpful resources for troubleshooting common issues, `Rwards` empowers users to learn from their mistakes in a supportive and fun way.
+The `Rwards` package turns R errors into opportunities for growth and engagement. Instead of dreading error messages, you earn **XP** for every error you hit — and **3× XP** the first time you encounter a new one. As your XP grows you climb **levels with playful titles** (Novice → Mastermind, or a `cyberpunk` theme: Wired Rookie → The Rootwalker), with a **progress bar** toward the next level and an encouraging message on every error. Your progress is **saved across R sessions**, so the goal is simple: take the anxiety out of mistakes and make learning R supportive and fun for newcomers.
 
 ## TODO
 - [x] Remove need to use evaluate_code
 - [x] Change error_tracker to progress tracker or exp (stay positive)
-- [ ] pride_colour color palette: new color when new error discovered
-- [ ] Add language (en/fr/de/...) option
 - [x] Add a sense of progression/level-up as a gratification mechanism (eg. novice, amateur, ..., bugmaster)
 - [x] Keep track of points between sessions? sort of a cache?
-- [ ] Remove redundant text in error message.
 - [x] Show progress until next level?
-- [ ] Couleur (pride color palette) pour découvrir une nouvelle erreur? 
+- [ ] pride_colour color palette: new color when new error discovered
+- [ ] Add language (en/fr/de/...) option
+- [ ] Remove redundant text in error message.
 - [ ] Put .onLoad inside zzz.R
 - [ ] Minimal doc
 - [ ] Contributor Guidelines
@@ -20,17 +19,25 @@ The `Rwards` package is designed to transform the experience of learning R by tu
 ## Getting Started
 
 
-To develop without having to install.
-```r 
+To develop without having to install:
+```r
 devtools::load_all()
-trythis
+
+# Trigger any error and watch your XP grow:
+sqrt("a")
 ```
 
-To install.
+To install from GitHub:
 ```r
-devtools::install("Rwards")
+devtools::install_github("mickaeltemporao/exceptional-Rwards")
 library(Rwards)
-trythis
+
+sqrt("a")
+```
+
+Prefer a cyberpunk flavour of level titles? Set this option (before or after loading):
+```r
+options(Rwards.theme = "cyberpunk")
 ```
 
 ## AI Acknowledgement

--- a/levels.md
+++ b/levels.md
@@ -1,9 +1,9 @@
-# Progress Levels?
+# Progress Levels
 
 ## XP Progression Tables
 
-- We can attribute 50XP per error/exception with new errors worth 3x (150xp)
-- Factor of x2.25 XP required from previous level
+- We attribute 50 XP per error/exception, with new (unique) errors worth 3x (150 XP)
+- XP required per level is not a fixed multiple — it ramps up steeply early (~2.25x at first) and eases off at higher levels, mirroring the Diablo 2 curve
 
 | Level | XP for LvL | Total XP |
 | ----- | ---------- | -------- |
@@ -18,7 +18,7 @@
 | 09    | 33750      | 109025   |
 | 10    | 45000      | 154025   |
 
-Assuiming an average of 50xp per error, this experience curve requires ~3000 errors to reach Levels 10. 
+Assuming an average of 50 XP per error, this experience curve requires ~3000 errors to reach Level 10. 
 - Of course, this is inspired by the D2 leveling-up curve...
 
 ### Basic Levels

--- a/pr_body.md
+++ b/pr_body.md
@@ -1,0 +1,11 @@
+This PR implements the Diablo 2 inspired XP and leveling system for Rwards.
+
+### Features
+- Introduces an XP scale where standard errors grant 50 XP and new errors grant 150 XP.
+- Adds level titles and allows users to switch between `basic` and `cyberpunk` themes via `options(Rwards.theme = "cyberpunk")`.
+- Integrates persistent caching utilizing `tools::R_user_dir` so progress is saved across R sessions.
+- Updates the progress bar format to track XP towards the next level limit.
+- Replaces generic error thresholds with random encouraging messages and special level-up announcements.
+- Adds a `testthat` suite to verify XP tracking, level thresholding, and themes.
+
+Resolves #4, Resolves #5, Resolves #6

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(Rwards)
+
+test_check("Rwards")

--- a/tests/testthat/test-levels.R
+++ b/tests/testthat/test-levels.R
@@ -29,31 +29,24 @@ test_that("Level XP and titles are calculated correctly", {
 })
 
 test_that("XP tracking increments correctly", {
-  # Set up a new isolated environment to mock the global one
-  old_tracker <- Rwards:::error_tracker
+  old_points <- error_tracker$points
+  old_types <- error_tracker$error_types
   
-  # Mock the tracker
-  mock_tracker <- new.env()
-  mock_tracker$error_types <- list()
-  mock_tracker$points <- 0
-  
-  # Inject mock tracker (using assignInNamespace to override temporarily if needed, 
-  # or simply knowing error_handler handles the global one. For a true unit test 
-  # it's best to mock, but since the package uses a global env, we can just reset it)
-  
-  Rwards:::error_tracker$error_types <- list()
-  Rwards:::error_tracker$points <- 0
+  error_tracker$error_types <- list()
+  error_tracker$points <- 0
   
   # Simulate first new error
   e1 <- simpleError("First test error")
-  Rwards:::error_handler(e1)
-  expect_equal(Rwards:::error_tracker$points, 150)
+  
+  # Use suppressMessages because error_handler calls message()
+  suppressMessages(error_handler(e1))
+  expect_equal(error_tracker$points, 150)
   
   # Simulate same error again
-  Rwards:::error_handler(e1)
-  expect_equal(Rwards:::error_tracker$points, 200) # 150 + 50
+  suppressMessages(error_handler(e1))
+  expect_equal(error_tracker$points, 200) # 150 + 50
   
   # Restore
-  Rwards:::error_tracker$error_types <- old_tracker$error_types
-  Rwards:::error_tracker$points <- old_tracker$points
+  error_tracker$error_types <- old_types
+  error_tracker$points <- old_points
 })

--- a/tests/testthat/test-levels.R
+++ b/tests/testthat/test-levels.R
@@ -1,0 +1,59 @@
+test_that("Level XP and titles are calculated correctly", {
+  # Level 1
+  info <- get_level_info(0)
+  expect_equal(info$level, 1)
+  expect_equal(info$title, "Novice")
+  
+  # Level 2 threshold
+  info2 <- get_level_info(500)
+  expect_equal(info2$level, 2)
+  expect_equal(info2$title, "Explorer")
+  
+  # Max Level
+  info_max <- get_level_info(200000)
+  expect_equal(info_max$level, 10)
+  expect_equal(info_max$title, "Mastermind")
+  
+  # Cyberpunk theme
+  options(Rwards.theme = "cyberpunk")
+  info_cyber <- get_level_info(500)
+  expect_equal(info_cyber$title, "Neon Scout")
+  
+  # Fallback to basic if invalid theme
+  options(Rwards.theme = "invalid_theme")
+  info_fallback <- get_level_info(500)
+  expect_equal(info_fallback$title, "Explorer")
+  
+  # Reset options
+  options(Rwards.theme = "basic")
+})
+
+test_that("XP tracking increments correctly", {
+  # Set up a new isolated environment to mock the global one
+  old_tracker <- Rwards:::error_tracker
+  
+  # Mock the tracker
+  mock_tracker <- new.env()
+  mock_tracker$error_types <- list()
+  mock_tracker$points <- 0
+  
+  # Inject mock tracker (using assignInNamespace to override temporarily if needed, 
+  # or simply knowing error_handler handles the global one. For a true unit test 
+  # it's best to mock, but since the package uses a global env, we can just reset it)
+  
+  Rwards:::error_tracker$error_types <- list()
+  Rwards:::error_tracker$points <- 0
+  
+  # Simulate first new error
+  e1 <- simpleError("First test error")
+  Rwards:::error_handler(e1)
+  expect_equal(Rwards:::error_tracker$points, 150)
+  
+  # Simulate same error again
+  Rwards:::error_handler(e1)
+  expect_equal(Rwards:::error_tracker$points, 200) # 150 + 50
+  
+  # Restore
+  Rwards:::error_tracker$error_types <- old_tracker$error_types
+  Rwards:::error_tracker$points <- old_tracker$points
+})


### PR DESCRIPTION
This PR implements the Diablo 2 inspired XP and leveling system for Rwards.

### Features
- Introduces an XP scale where standard errors grant 50 XP and new errors grant 150 XP.
- Adds level titles and allows users to switch between `basic` and `cyberpunk` themes via `options(Rwards.theme = "cyberpunk")`.
- Integrates persistent caching utilizing `tools::R_user_dir` so progress is saved across R sessions.
- Updates the progress bar format to track XP towards the next level limit.
- Replaces generic error thresholds with random encouraging messages and special level-up announcements.
- Adds a `testthat` suite to verify XP tracking, level thresholding, and themes.

Resolves #4, Resolves #5, Resolves #6
